### PR TITLE
Add a Virtual MediaType based on VENDOR_ID

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -97,6 +97,7 @@ pub enum MediaType {
     SolidState,
     Rotational,
     Loopback,
+    Virtual,
     Unknown,
 }
 
@@ -487,7 +488,18 @@ fn get_media_type(device: &libudev::Device) -> MediaType {
                 return MediaType::Rotational;
             }
         }
-        None => return MediaType::Unknown,
+        None => {
+            match device.property_value("ID_VENDOR") {
+                Some(s) => {
+                    let value = s.to_string_lossy();
+                    match value.as_ref() {
+                        "QEMU" => return MediaType::Virtual,
+                        _ => return MediaType::Unknown,
+                    }
+                }
+                None => return MediaType::Unknown,
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Doing `udevadm info <devnode>` on a virtio-scsi device does not return
ID_ATA_ROTATION_RATE_RPM property.

It does not mean that we cannot detect a MediaType and proceed with
using that device.

Since using virual devices is useful for testing purposes, this change
is about adding a new "Virtual" MediaType based upon a vendor id:

ID_VENDOR=QEMU